### PR TITLE
Added isFinishing() to WeatherActivity.java

### DIFF
--- a/MaterialWeather/app/src/main/java/com/survivingwithandroid/materialweather/WeatherActivity.java
+++ b/MaterialWeather/app/src/main/java/com/survivingwithandroid/materialweather/WeatherActivity.java
@@ -102,6 +102,7 @@ public class WeatherActivity extends ActionBarActivity {
         if (id == R.id.action_search) {
             // We show the dialog
             Dialog d = createDialog();
+            if(!isFinishing())
             d.show();
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
If the activity closes before the Dialog is displayed, then the context of the dialog would be undefined and the app would crash. Corrected it by adding if(!isFinishing()) before dialog.show()
